### PR TITLE
Use cygdrive prefix for secrets file path.

### DIFF
--- a/rsyncd.conf
+++ b/rsyncd.conf
@@ -57,7 +57,7 @@ lock file = c:/rsyncd/rsyncd.lock
     # and the c:/rsyncd/rsyncd.secrets files)
     auth users = UUU
     # Password to match $Conf(RsyncdPasswd)
-    secrets file = c:/rsyncd/rsyncd.secrets
+    secrets file = /cygdrive/c/rsyncd/rsyncd.secrets
     # List the IP address(es) of your BackupPC server(s), so only connections from these hosts will be allowed.
     hosts allow = 192.1.1.100, 192.1.1.101
     # Allows restores to write to this share
@@ -74,7 +74,7 @@ lock file = c:/rsyncd/rsyncd.lock
 #    comment = Documents and Settings
 #    strict modes = false
 #    auth users = backuppc
-#    secrets file = c:/rsyncd/rsyncd.secrets
+#    secrets file = /cygdrive/c/rsyncd/rsyncd.secrets
 #    hosts allow = 192.1.1.100, 192.1.1.101
 #    read only = true
 #    list = true


### PR DESCRIPTION
BackupPC server attempts to access client modules listed in the sample
rsyncd.conf file shipped with cygwin-rsyncd will be denied because of
the use of native Windows paths in the secrets file configuration,
e.g. c:/rsyncd/rsyncd.secrets, presumably because the RsyncServer
process can't find the file.  Using the "cygdrive" prefix in the path,
i.e. /cygdrive/c/rsyncd/rsyncd.secrets, allows module access to
succeed.